### PR TITLE
fix: falsch benannte Klasse

### DIFF
--- a/addons/RB205_phase1/config.cpp
+++ b/addons/RB205_phase1/config.cpp
@@ -1,6 +1,6 @@
 class cfgPatches
 {
-    class RB205_main
+    class RB205_phase1
 	{
 		requiredAddons[]=
 		{


### PR DESCRIPTION
Bug gefixt, wodurch die Fahrzeuge im Zeus nicht angezeigt wurden
