### PR TITLE
add: empty crate variants

### DIFF
--- a/addons/RB205_logistics/config.cpp
+++ b/addons/RB205_logistics/config.cpp
@@ -20,7 +20,12 @@ class CfgPatches
 			"RB205_resupply_weapons",
 			"RB205_resupply_medical",
 			"RB205_resupply_equipment",
-			"RB205_resupply_arsenal"
+			"RB205_resupply_arsenal",
+			"RB205_resupply_base",
+			"RB205_resupply_weapons_empty",
+			"RB205_resupply_medical_empty",
+			"RB205_resupply_blue_empty",
+			"RB205_resupply_red_empty"
 		};
 		weapons[]={};
 	};
@@ -46,6 +51,10 @@ class CfgEditorSubcategories
 	{
 		displayName = "Crates";
 	};
+	class RB205_crates_empty
+	{
+		displayName = "Crates (Empty)";
+	};
 };
 
 
@@ -53,7 +62,7 @@ class CfgEditorSubcategories
 #define ACE_CARGO \
 	ace_cargo_size = 1; \
 	ace_cargo_canLoad = 1; \
-	ace_cargo_noRename = 1; \
+	ace_cargo_noRename = 0; \
 	ace_cargo_blockUnloadCarry = 0;
 
 #define CARRYABLE \
@@ -218,6 +227,50 @@ class CfgVehicles
 		class TransportBackpacks{};
 		scope		= 2;
 		scopeCurator= 2;
+	};
+
+	class RB205_resupply_base: 3AS_Supply_Large_Prop
+	{
+		displayName = "[205] Resupply Crate";
+		editorCategory = "RB205_prop";
+		editorSubcategory = "RB205_crates_empty";
+		INVENTORY_SPACE
+		ACE_CARGO
+		class TransportWeapons{};
+		class TransportMagazines{};
+		class TransportItems{};
+		class TransportBackpacks{};
+		scope		= 2;
+		scopeCurator= 2;
+	};
+	class RB205_resupply_weapons_empty: RB205_resupply_base
+	{
+		displayName = "[205] Resupply Crate (Weapons/Ammo)";
+		editorPreview = "\3as\3as_props\Crates\EditorPreviews\3AS_Supply_Large_Ammo_Prop.jpg";
+		hiddenSelections[] = {"camo1"};
+		hiddenSelectionsMaterials[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Ammo\Supply_Large_Ammo.rvmat"};
+		hiddenSelectionsTextures[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Ammo\Supply_Large_Ammo_co.paa"};
+	};
+	class RB205_resupply_medical_empty: RB205_resupply_base
+	{
+		displayName = "[205] Resupply Crate (Medical)";
+		hiddenSelections[] = {"camo1"};
+		hiddenSelectionsMaterials[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Medical\Supply_Large_Medical.rvmat"};
+		hiddenSelectionsTextures[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Medical\Supply_Large_Medical_co.paa"};
+	};
+	class RB205_resupply_blue_empty: RB205_resupply_base
+	{
+		displayName = "[205] Resupply Crate (Blue)";
+		hiddenSelections[] = {"camo1"};
+		hiddenSelectionsMaterials[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Blue\Supply_Large_Blue.rvmat"};
+		hiddenSelectionsTextures[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Blue\Supply_Large_Blue_co.paa"};
+	};
+	class RB205_resupply_red_empty: RB205_resupply_base
+	{
+		displayName = "[205] Resupply Crate (Red)";
+		hiddenSelections[] = {"camo1"};
+		hiddenSelectionsMaterials[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Red\Supply_Large_Red.rvmat"};
+		hiddenSelectionsTextures[] = {"3AS\3AS_Props\Crates\Data\Supply_Large_Red\Supply_Large_Red_co.paa"};
 	};
 };
 


### PR DESCRIPTION
Leere Kiste in den Varianten: Standard, Medizinisch, Munition, sowie in den Farben Blau und Rot hinzugefügt
