### PR TITLE
fix: TFAR-Werte bei GM Rucksäcken

### DIFF
--- a/addons/RB205_main/cfgVehicles.hpp
+++ b/addons/RB205_main/cfgVehicles.hpp
@@ -752,6 +752,7 @@ class RB205_B_snow_radio: RB205_B_snow_heavy
 	displayName = "[205] Clone Snow Trooper Backpack <RTO>";
 	maximumLoad = INV_BACK_RADIO;
 	picture = "\RB205_main\data\ui\backpacks\icon_B_snow_radio.paa";
+	TFAR_RADIO
 };
 
 class SWLB_clone_arc_backpack;

--- a/addons/RB205_main/cfgVehicles_baseClasses.hpp
+++ b/addons/RB205_main/cfgVehicles_baseClasses.hpp
@@ -536,4 +536,5 @@ class RB205_B_snow_base: LST_21_BackPack
 		"RB205_main\data\materials\B_snow.rvmat",
 		"RB205_main\data\materials\B_snow_cloth.rvmat"
 	};
+	tf_hasLRradio = 0;
 };


### PR DESCRIPTION
LR entfernt bei AT, Med, Hvy, ... ; LR Interface hinzugefügt bei Radio
