### PR TITLE
Behebung von Fehlermeldungen in der RPT-Datei

### DIFF
--- a/addons/RB205_custom/2111_pain/config.cpp
+++ b/addons/RB205_custom/2111_pain/config.cpp
@@ -7,7 +7,7 @@ class cfgPatches
             "RB205_main",
             "RB205_custom"
         };
-        author = "205th Recon Battalion"
+        author = "205th Recon Battalion";
         requiredVersion = 1.0;
         weapons[] =
         {

--- a/addons/RB205_custom/5567_flank/config.cpp
+++ b/addons/RB205_custom/5567_flank/config.cpp
@@ -37,7 +37,7 @@ class cfgWeapons
         {
             model = "RB205_H_custom";
             id = "5567";
-            var = "dft"
+            var = "dft";
         };
     };
 

--- a/addons/RB205_custom/8550_spark/config.cpp
+++ b/addons/RB205_custom/8550_spark/config.cpp
@@ -34,7 +34,7 @@ class cfgWeapons
     class RB205_H_lieutenant;
     class RB205_H_spark: RB205_H_lieutenant
     {
-        displayName = "[205] Clone Commander Helmet [8550]"
+        displayName = "[205] Clone Commander Helmet [8550]";
         hiddenSelectionsTextures[] =
         {
             "RB205_custom\8550_spark\data\H_spark.paa",
@@ -53,7 +53,7 @@ class cfgWeapons
     class RB205_H_arf_lieutenant;
     class RB205_H_arf_spark: RB205_H_arf_lieutenant
     {
-        displayName = "[205] Clone ARF Commander Helmet [8550]"
+        displayName = "[205] Clone ARF Commander Helmet [8550]";
         hiddenSelectionsTextures[] =
         {
             "RB205_custom\8550_spark\data\H_spark_arf.paa",
@@ -95,7 +95,7 @@ class cfgWeapons
     class RB205_V_spark: RB205_V_commander_base
     {
         ACCESS_TRUE
-        displayName = "[205] Clone Commander Vest [8550]"
+        displayName = "[205] Clone Commander Vest [8550]";
         model = "\SWLB_clones\SWLB_clone_commander_armor.p3d";
         hiddenSelections[] = {"camo1","rank"};
         hiddenSelectionsMaterials[]=

--- a/addons/RB205_logistics/config.cpp
+++ b/addons/RB205_logistics/config.cpp
@@ -29,9 +29,6 @@ class CfgPatches
 		};
 		weapons[]={};
 	};
-	class RB205_marker
-    {
-    };
 };
 
 class CfgEditorCategories

--- a/addons/RB205_vehicles/catfish/config.cpp
+++ b/addons/RB205_vehicles/catfish/config.cpp
@@ -1,6 +1,6 @@
 class cfgPatches
 {
-    class RB205_vehicles_av7
+    class RB205_vehicles_catfish
 	{
 		requiredAddons[]=
 		{

--- a/addons/RB205_vehicles/tx130/config.cpp
+++ b/addons/RB205_vehicles/tx130/config.cpp
@@ -14,7 +14,7 @@ class cfgPatches
 		{
 			"RB205_tx130",
 			"RB205_tx130_gl",
-			"RB205_tx130_aa",
+			//"RB205_tx130_aa",
 			"RB205_tx130_recon",
 			"RB205_tx130_super"
 		};
@@ -147,7 +147,7 @@ class cfgVehicles
 			};
 		};
 	};
-	class RB205_tx130_aa: 3as_saber_AA
+	/*class RB205_tx130_aa: 3as_saber_AA
 	{
 		ACCESS_TRUE
 		displayName="TX-130/AA";
@@ -203,7 +203,7 @@ class cfgVehicles
 				};
 			};
 		};
-	};
+	};*/
 	class RB205_tx130_recon: 3as_saber_m1Recon
 	{
 		ACCESS_TRUE

--- a/addons/RB205_weapons/BTX42/config.cpp
+++ b/addons/RB205_weapons/BTX42/config.cpp
@@ -1,6 +1,6 @@
 class cfgPatches
 {
-	class RB205_weapons_z6
+	class RB205_weapons_btx42
 	{
 		requiredAddons[]=
 		{

--- a/addons/RB205_weapons/config.cpp
+++ b/addons/RB205_weapons/config.cpp
@@ -180,7 +180,7 @@ class CfgMagazines
 		tracersEvery=1;
 		lastRoundsTracer = 30;
 		descriptionShort = "$STR_205_Compact_Energy_Pack_DescriptionShort";
-        author = "205th Recon Battalion"
+        author = "205th Recon Battalion";
 	};
 	// SE-14r, RK-3, EC-17
 	class RB205_Compact_Energy_Pack_red: RB205_Compact_Energy_Pack


### PR DESCRIPTION
Hinzufügen von Semikolon,
Umbenennung von Klassennamen in cfgPatches,
Entfernung des TX-130 AA da es die Vorlage nicht mehr gibt