### PR TITLE
update: AT-RT Funktionen

### DIFF
--- a/addons/RB205_vehicles/atrt/config.cpp
+++ b/addons/RB205_vehicles/atrt/config.cpp
@@ -5,7 +5,8 @@ class cfgPatches
 		requiredAddons[]=
 		{
 			"RB205_vehicles",
-			"3AS_ATRT"
+			"3AS_ATRT",
+			"3AS_Main_Function_Library"
 		};
 		requiredVersion = 1.0;
         author = "205th Recon Battalion";
@@ -24,10 +25,12 @@ class cfgPatches
 #include "\RB205_vehicles\macros.hpp"
 #include "\RB205_vehicles\inventory.hpp"
 
+//class CBA_Extended_EventHandlers_base;
+
 class cfgVehicles
 {
-	class 3AS_ATRT;
-	class RB205_atrt: 3AS_ATRT
+	class 3AS_ATRT_Base;
+	class RB205_atrt: 3AS_ATRT_Base
 	{
 		ACCESS_TRUE
 		displayName = "AT-RT";
@@ -39,6 +42,8 @@ class cfgVehicles
 		editorSubcategory = "RB205_veh_ground";
 		editorPreview = "";
 		//Texture
+		model="\3AS\ATRT\3AS_ATRT.p3d";
+		modelSides[]={3,1,0,2};
 		hiddenSelectionsMaterials[] =
 		{
 			"RB205_vehicles\atrt\data\atrt.rvmat"
@@ -61,6 +66,21 @@ class cfgVehicles
 			"RB205_barc_mag",
 			"RB205_barc_mag",
 			"RB205_barc_mag"
+		};
+		linkedItems[]=
+		{
+			"ItemMap",
+			"ItemCompass",
+			"ItemGPS",
+			"ItemWatch",
+			"ItemRadio"
+		};
+		respawnWeapons[]={};
+		respawnMagazines[]={};
+		class Wounds
+		{
+			tex[]={};
+			mat[]={};
 		};
 	};
 };
@@ -102,6 +122,7 @@ class cfgWeapons
 				item = "acc_flashlight";
 			};
 		};
+		fireLightDiffuse[] = {0,0,1};
 	};
 };
 
@@ -111,5 +132,45 @@ class CfgWeaponCursors
 	class RB205_CH_atrt: throw
 	{
 		texture = "\A3\ui_f\data\igui\cfg\weaponcursors\rocket_gs.paa";
+	};
+};
+
+class cfgFunctions
+{
+	class RB205
+	{
+		class RB205_ATRT
+		{
+			file = "\RB205_vehicles\atrt\functions";
+			class initATRT
+			{
+			};
+			/*class mountATRT
+			{
+			};*/
+			class unstuckATRT
+			{
+			};
+			class repairAfterCollisionATRT
+			{
+			};
+			class disassembleATRT
+			{
+			};
+			class repairATRT
+			{
+			};
+		};
+	};
+};
+
+class Extended_Init_EventHandlers
+{
+	class RB205_atrt
+	{
+		class RB205_atrt_Init
+		{
+			init = "(_this select 0) call RB205_fnc_initATRT";
+		};
 	};
 };

--- a/addons/RB205_vehicles/atrt/functions/fn_disassembleATRT.sqf
+++ b/addons/RB205_vehicles/atrt/functions/fn_disassembleATRT.sqf
@@ -1,0 +1,28 @@
+/*
+ * Author: Spark (205th Recon Battalion)
+ * Deletes the AT-RT to simulate Loading him into another vehicle
+ *
+ * Arguments:
+ * atrt: Object - The AT-RT to teleport
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * atrt call RB205_fnc_disassembleATRT;
+ */
+
+params ["_atrt"];
+
+atrtHelp = _atrt;
+[
+    ["Are you sure you want to disassemble the AT-RT? This will render the AT-RT useless and cannot be undone."],
+    "Disassemble AT-RT",
+    {
+        if _confirmed then {
+            deleteVehicle atrtHelp;
+        };
+    },
+    "",
+    ""
+] call CAU_UserInputMenus_fnc_guiMessage;

--- a/addons/RB205_vehicles/atrt/functions/fn_initATRT.sqf
+++ b/addons/RB205_vehicles/atrt/functions/fn_initATRT.sqf
@@ -1,0 +1,202 @@
+/*
+ * Author: 3AS, Edited DartRuffian
+ * Creates mount/dismount actions for an AT-RT object.
+ *
+ * Arguments:
+ * atrt: Object - The AT-RT
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * init = "(_this select 0) call TAS_fnc_initATRT";
+ */
+
+
+#define ATRT_BASE_HEALTH 50
+params ["_atrt"];
+if (isNull _atrt) exitWith {};
+
+_atrt setAnimSpeedCoef 1.5; // Used to increase movement speed //Might be better to set the Speed in the ATRT_Base Config class instead of this. ~Jek
+_atrt disableAI "RADIOPROTOCOL"; // Stops ai from talking/sending messages
+
+_this disableAI "AIMINGERROR";
+_this disableAI "AUTOTARGET";
+_this disableAI "AUTOCOMBAT";
+_this disableAI "MOVE";
+
+_atrt addEventHandler
+[
+    "HandleDamage",
+    {
+        params ["_atrt", "", "_damage", "", "", "", "", ""];
+        private ["_atrtHealth"];
+
+        _atrtHealth = _atrt getVariable ["TAS_ATRT_Health", ATRT_BASE_HEALTH]; //Sets Variable to ATRT_BASE_HEALTH if Variable not Set
+        _atrtHealth = _atrtHealth - _damage;
+        _atrt setVariable ["TAS_ATRT_Health", _atrtHealth, true];
+
+		//Kill ATRT if health is 0 or less.
+        if (_atrtHealth <= 0) then
+        {
+            _atrt call TAS_fnc_spawnATRTSmoke;
+            _atrt call TAS_fnc_dismountATRT;
+            _atrt setDamage 1;
+
+            _atrt removeEventHandler [_thisEvent, _thisEventHandler];
+        };
+
+        0;
+    }
+];
+
+_atrt addEventHandler
+[
+    "Deleted",
+    {
+        // Clears up particles that are spawned by BNAKC_fnc_spawnATRTSmoke before the object is deleted
+        params ["_entity"];
+        private _allEffects = _entity getVariable ["TAS_ATRT_effects", []];
+        { deleteVehicle _x; } forEach _allEffects;
+    }
+];
+
+_atrt addAction
+[
+    "Drive",
+    {
+        //       _target, _caller
+        params ["_atrt", "_rider", "", ""];
+
+        _rider = _atrt getVariable ["TAS_ATRT_rider", _rider]; //Sets Variable to _rider if Variable not set
+        [_rider, _atrt] call TAS_fnc_mountATRT;
+
+        // Check if the player should be able to ride
+        waitUntil
+        {
+            sleep 2;
+            private _expression =
+            (
+                // Rider Checks
+                !alive _rider or
+                lifeState _rider == "INCAPACITATED" or
+                _rider getVariable ["ACE_isUnconscious", false]
+            );
+            // See https://community.bistudio.com/wiki/waitUntil#Problems
+            !isNil "_expression" and { _expression };
+        };
+
+        _atrt call TAS_fnc_dismountATRT;
+    },
+    [],
+    1.5,
+    true,
+    true,
+    "",
+    "_this != _originalTarget and alive _target", // Prevents rider from seeing mount action,
+    4,                                            // and from players getting stuck on dead units
+    false,
+    "",
+    ""
+];
+
+_atrt addAction
+[
+    "Dismount",
+    {
+        //       _target,  _caller
+        params ["", "_atrt", "", ""];
+        _atrt call TAS_fnc_dismountATRT;
+    },
+    nil,
+    1.5,
+    false,
+    true,
+    "",
+    "_this == _originalTarget", // Prevent multiple addActions
+    2,
+    false,
+    "",
+    ""
+];
+
+
+
+/* 205th Additions */
+
+_atrt addAction
+[
+    "<t color='#FF9800'>Unstuck</t>",
+    {
+        //       _target,  _caller
+        params ["", "_atrt", "", ""];
+        _atrt call RB205_fnc_unstuckATRT;
+    },
+    nil,
+    1.5,
+    false,
+    true,
+    "",
+    "_this == _originalTarget", // Prevent multiple addActions
+    2,
+    false,
+    "",
+    ""
+];
+_atrt addAction
+[
+    "<t color='#FF9800'>Repair (Collision)</t>",
+    {
+        //       _target, _caller
+        params ["_atrt", "_rider", "", ""];
+        _atrt call RB205_fnc_repairAfterCollisionATRT;
+    },
+    [],
+    1.5,
+    true,
+    true,
+    "",
+    "_this != _originalTarget and alive _target", // Prevents rider from seeing mount action,
+    4,                                            // and from performing this action on dead units
+    false,
+    "",
+    ""
+];
+_atrt addAction
+[
+    "<t color='#FF0000'>Disassemble</t>",
+    {
+        //       _target, _caller
+        params ["_atrt", "_rider", "", ""];
+        _atrt call RB205_fnc_disassembleATRT;
+    },
+    [],
+    1.5,
+    true,
+    true,
+    "",
+    "_this != _originalTarget and alive _target", // Prevents rider from seeing mount action,
+    4,                                            // and from performing this action on dead units
+    false,
+    "",
+    ""
+];
+_atrt addAction
+[
+    "<t color='#98FF00'>Repair</t>",
+    {
+        //       _target, _caller
+        params ["_atrt", "_rider", "", ""];
+        _atrt call RB205_fnc_repairATRT;
+    },
+    [],
+    1.5,
+    true,
+    true,
+    "",
+    "_this != _originalTarget and !alive _target and 'ToolKit' in (items player)", // Prevents rider from seeing mount action,
+    4,                                            // and from performing this action on dead units
+    false,
+    "",
+    ""
+];

--- a/addons/RB205_vehicles/atrt/functions/fn_repairATRT.sqf
+++ b/addons/RB205_vehicles/atrt/functions/fn_repairATRT.sqf
@@ -1,0 +1,26 @@
+/*
+ * Author: Spark (205th Recon Battalion)
+ * Repairs the AT-RT by deleting the unit and spawning a new one
+ *
+ * Arguments:
+ * atrt: Object - The AT-RT to teleport
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * atrt call RB205_fnc_repairATRT;
+ */
+
+params ["_atrt"];
+private ["_class", "_position", "_side", "_direction"];
+
+_class = typeOf _atrt;
+_position = getPos _atrt;
+_side = WEST; //TODO: getSide before death
+_direction = getDir _atrt ;
+
+deleteVehicle _atrt;
+
+_atrtNew = (createGroup _side) createUnit [_class, _position, [], 0, "NONE"];
+_atrtNew setDir _direction;

--- a/addons/RB205_vehicles/atrt/functions/fn_repairAfterCollisionATRT.sqf
+++ b/addons/RB205_vehicles/atrt/functions/fn_repairAfterCollisionATRT.sqf
@@ -1,0 +1,25 @@
+/*
+ * Author: Spark (205th Recon Battalion)
+ * Deletes the AT-RT and spawns a new one to repair it,
+ * once the movement is broken due to a collision with another AT-RT
+ *
+ * Arguments:
+ * atrt: Object - The AT-RT to teleport
+ *
+ * Return Value:
+ * None
+ *
+ * Example:
+ * atrt call RB205_fnc_repairAfterCollisionATRT;
+ */
+
+params ["_atrt"];
+private ["_class", "_spawnPosition", "_side"];
+
+_class = typeOf _atrt;
+_spawnPosition = _atrt call RB205_fnc_unstuckATRT;
+_side = side _atrt;
+
+deleteVehicle _atrt;
+
+_class createUnit [_spawnPosition, createGroup _side];

--- a/addons/RB205_vehicles/atrt/functions/fn_unstuckATRT.sqf
+++ b/addons/RB205_vehicles/atrt/functions/fn_unstuckATRT.sqf
@@ -1,0 +1,43 @@
+/*
+ * Author: Spark (205th Recon Battalion)
+ * Teleports the AT-RT backwards in order to get it unstuck from bushes etc.
+ *
+ * Arguments:
+ * atrt: Object - The AT-RT to teleport
+ *
+ * Return Value:
+ * New AT-RT position
+ *
+ * Example:
+ * atrt call RB205_fnc_unstuckATRT;
+ */
+
+#define TELEPORT_LENGTH 2
+
+params ["_atrt"];
+private ["_direction", "_position", "_positionAfterTeleport"];
+
+_direction = getDir _atrt;
+_position = getPos _atrt;
+_positionAfterTeleport = _position;
+
+switch (true) do {
+    case (_direction <= 45) : {
+        _positionAfterTeleport = [(_position select 0), (_position select 1) - TELEPORT_LENGTH, (_position select 2)]
+    };
+    case ((_direction > 45) && (_direction <= 135)) : {
+        _positionAfterTeleport = [(_position select 0) - TELEPORT_LENGTH, (_position select 1), (_position select 2)]
+    };
+    case ((_direction > 135) && (_direction <= 225)) : {
+        _positionAfterTeleport = [(_position select 0), (_position select 1) + TELEPORT_LENGTH, (_position select 2)]
+    };
+    case ((_direction > 225) && (_direction <= 315)) : {
+        _positionAfterTeleport = [(_position select 0) + TELEPORT_LENGTH, (_position select 1), (_position select 2)]
+    };
+    case (_direction > 315) : {
+        _positionAfterTeleport = [(_position select 0), (_position select 1) - TELEPORT_LENGTH, (_position select 2)]
+    };
+};
+_atrt setPos _positionAfterTeleport;
+
+_positionAfterTeleport;


### PR DESCRIPTION
Sprintgeschwindigkeit auf 49 km/h erhöht; selbstständiges bewegen des AT-RT unterbunden; Interaktion zum "unstucken", zum reparieren nachdem man Gegeneinander gelaufen ist, zum löschen des AT-RT und zum reparieren (falls ein Werkzeugkasten vorhanden ist)
